### PR TITLE
Add background color declarations for sides screen and compose watches

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -82,6 +82,11 @@ services:
           context: ./src/human-visualizer
           additional_contexts:
             util: ./src/shared/code
+        develop:
+            watch:
+            - action: sync
+              path: ./src/human-visualizer/visualizer
+              target: /app/visualizer
         ports:
             - 5001:8000        
         restart: unless-stopped
@@ -97,6 +102,11 @@ services:
           additional_contexts:
             util: ./src/shared/code
             models: ./src/shared/models
+        develop:
+            watch:
+            - action: sync
+              path: ./src/neural-net-visualizer/visualizer
+              target: /app/visualizer
         ports:
             - 5002:8000        
         restart: unless-stopped

--- a/src/human-visualizer/visualizer/style.css
+++ b/src/human-visualizer/visualizer/style.css
@@ -1,6 +1,7 @@
 * {
     margin: 0;
     padding: 0;
+    background-color: white;
  }
  
  body, html {

--- a/src/neural-net-visualizer/visualizer/style.css
+++ b/src/neural-net-visualizer/visualizer/style.css
@@ -1,6 +1,7 @@
 * {
    margin: 0;
    padding: 0;
+   background-color: white;
 }
 
 body, html {


### PR DESCRIPTION
As mentioned in #235, the side screens do not declare a background color, simply depending on the browser to default to white. This becomes a problem when the pages are embedded, such as in the development environment. This adds the background colors, as well as docker compose watch declarations which assist in development of these modules